### PR TITLE
adds pry as a test dep and specs for matches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,4 +58,5 @@ end
 
 group :test do
   gem 'database_cleaner'
+  gem 'pry', '~> 0.13.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     choice (0.2.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     database_cleaner (2.0.1)
@@ -141,6 +142,9 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     pg (1.3.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
     puma (5.6.2)
       nio4r (~> 2.0)
@@ -246,6 +250,7 @@ DEPENDENCIES
   jbuilder
   jwt
   pg (~> 1.3.3)
+  pry (~> 0.13.1)
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.2, >= 7.0.2.2)

--- a/app/controllers/match_controller.rb
+++ b/app/controllers/match_controller.rb
@@ -18,7 +18,7 @@ class MatchController < ApplicationController
 
   def start
     @room = Room.find(@decoded[:room_id])
-    @room.update_attribute(:stage, 'onging')
+    @room.update!(stage: 'ongoing')
   end
 
   def end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -11,7 +11,7 @@ class Match < ApplicationRecord
   end
 
   def calculate_winnings
-    if self.results.count(&:win?)
+    if self.results.any?(&:win?)
       self.update_attribute(:winnings, self.results.sum(&:wager) / self.results.count(&:win?))
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'pry'
+
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production

--- a/spec/requests/matches/create_match_spec.rb
+++ b/spec/requests/matches/create_match_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'swagger_helper'
+
+RSpec.describe "Matches", type: :request do
+  path "/match" do
+    post "create a match" do
+      tags "Matches#create"
+      consumes "application/json"
+      produces "application/json"
+      security [JWT: {}]
+
+      parameter name: 'Authorization', :in => :header, :type => :string
+
+      let(:'Authorization') { "Bearer #{authenticate(player, room)}" }
+
+      parameter name: :params, in: :body, schema: {
+        type: :object,
+        properties: {
+            match: {
+              type: :object,
+              properties: {
+                stake: { type: :string, format: :decimal },
+                contestants: {
+                  type: :array,
+                  items: {
+                    type: :object,
+                    properties: {
+                      name: { type: :string },
+                    },
+                    required: %w(name)
+                  }
+                },
+              },
+              required: %w(stake)
+            }
+        },
+        required: %w(match)
+      }
+
+      let(:player) { FactoryBot.create(:player, name: 'active player', owner: true, room: room) }
+      let(:room) { FactoryBot.create(:room,) }
+
+      let(:params) {
+        {
+          match: {
+            stake: 2.5,
+            contestants: [
+              { name: 'Lightning McQueen' },
+              { name: 'Tow Mater' },
+              { name: 'Sanic' },
+            ],
+          }
+        }
+      }
+
+      response '200', 'response received' do
+        schema type: :object,
+          properties: {
+            next_stage: { type: :string },
+          },
+          required: %w(next_stage)
+
+        it 'succeeds with a 200 and the current round standings' do |example|
+          expect{submit_request(example.metadata)}.to change{room.matches.count}.from(0).to(1)
+
+          assert_response_matches_metadata(example.metadata)
+
+          expect(response_json[:next_stage]).to eq 'betting'
+          match = room.active_match
+          expect(match.contestants.count).to eq 3
+          expect(match.wager).to eq 2.5
+
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/matches/end_match_spec.rb
+++ b/spec/requests/matches/end_match_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+require 'swagger_helper'
+
+RSpec.describe "Matches", type: :request do
+  path "/end" do
+    post "end a match" do
+      tags "Matches#end"
+      consumes "application/json"
+      produces "application/json"
+      security [JWT: {}]
+
+      parameter name: 'Authorization', :in => :header, :type => :string
+
+      let(:'Authorization') { "Bearer #{authenticate(player, room)}" }
+
+      parameter name: :params, in: :body, schema: {
+        type: :object,
+        properties: {
+            match: {
+              type: :object,
+              properties: {
+                match_id: { type: :string },
+                contestant_id: { type: :string },
+              },
+              required: %w(match_id, contestant_id)
+            }
+        },
+        required: %w(match)
+      }
+
+      let(:room) { FactoryBot.create(:room, :populated, stage: 'ongoing') }
+      let(:player) do
+        FactoryBot.create(
+          :player,
+          :with_bet,
+          name: 'active player',
+          owner: true,
+          room: room,
+          contestant: room.active_match.sorted_contestants.first,
+        )
+      end
+
+      let(:params) {
+        {
+          match: {
+            match_id: room.active_match.id,
+            contestant_id: room.active_match.sorted_contestants.first.id,
+          }
+        }
+      }
+
+      response '200', 'response received' do
+        schema type: :object,
+          properties: {
+            next_stage: { type: :string },
+          },
+          required: %w(next_stage)
+
+        it 'succeeds with a 200 and the current round standings' do |example|
+          expect{
+            submit_request(example.metadata)
+          }.to change{
+            room.reload.stage
+          }.from('ongoing').to('results')
+
+          assert_response_matches_metadata(example.metadata)
+
+          expect(response_json[:next_stage]).to eq 'results'
+
+          match = room.matches.first
+          expect(match.stage).to eq 'inactive'
+          expect(match.results.count(&:win?)).to eq 2
+          expect(match.winnings).to eq 3
+
+          expect(player.results.first.win?).to eq true
+
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/matches/start_match_spec.rb
+++ b/spec/requests/matches/start_match_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'swagger_helper'
+
+RSpec.describe "Matches", type: :request do
+  path "/start" do
+    post "start a match" do
+      tags "Matches#start"
+      consumes "application/json"
+      produces "application/json"
+      security [JWT: {}]
+
+      parameter name: 'Authorization', :in => :header, :type => :string
+
+      let(:'Authorization') { "Bearer #{authenticate(player, room)}" }
+
+      parameter name: :params, in: :body, schema: {
+        type: :object,
+        properties: {
+            match: {
+              type: :object,
+              properties: {
+                match_id: { type: :string },
+              },
+              required: %w(match_id)
+            }
+        },
+        required: %w(match)
+      }
+
+      let(:player) { FactoryBot.create(:player, name: 'active player', owner: true, room: room) }
+      let(:room) { FactoryBot.create(:room, :populated, stage: 'betting') }
+
+      let(:params) {
+        {
+          match: {
+            match_id: room.active_match.id,
+          }
+        }
+      }
+
+      response '200', 'response received' do
+        schema type: :object,
+          properties: {
+            next_stage: { type: :string },
+          },
+          required: %w(next_stage)
+
+        it 'succeeds with a 200 and the current round standings' do |example|
+          expect{submit_request(example.metadata)}.to change{room.reload.stage}.from('betting').to('ongoing')
+
+          assert_response_matches_metadata(example.metadata)
+          expect(response_json[:next_stage]).to eq 'ongoing'
+
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
adds pry as a dependency for testing so that we can add 
```
binding.pry
``` 
specs and controllers like to halt the execution and interact with the available objects in scope. 

This was extra added along with the intended purpose of adding specs for the match endpoints. 